### PR TITLE
install freeradius

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN \
     build-essential \
     curl \
     dsniff \
+    freeradius \
     fping \
     gcc \
     git \


### PR DESCRIPTION
FYI I haven't actually tested this image. I've been using faucet/Dockerfile.tests with the install freeradius (below).
This should be the only change required here, the main faucet repo's test cases will change any radius config files.


```
## Image name: faucet/tests
FROM faucet/test-base:latest
RUN $AG install freeradius
COPY ./ /faucet-src/
...
```