### PR TITLE
Update software versions in test base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 
 FROM ubuntu:18.04
 
-ENV MININETV="2.3.0d6"
 ENV OVSV="v2.15.0"
+ENV MININETV="2.3.0"
 
 ENV AG="apt-get -qqy --no-install-recommends -o=Dpkg::Use-Pty=0"
 ENV SETUPQ="setup.py -q easy_install --always-unzip ."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ## Image name: faucet/test-base
 ## Base image for FAUCET tests.
 
-FROM ubuntu:18.04
+FROM debian:buster
 
 ENV OVSV="v2.15.0"
 ENV MININETV="2.3.0"
@@ -21,7 +21,7 @@ COPY etc/init.d/docker /docker.init.d
 RUN mkdir -p ${BUILD_DIR} \
     && mv /setup.sh /setupproxy.sh /dind.sh /docker.init.d "${BUILD_DIR}" \
     && ${BUILD_DIR}/setupproxy.sh \
-    && sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list \
+    && cat /usr/share/doc/apt/examples/sources.list | sed -e 's/#deb-src/deb-src/' > /etc/apt/sources.list \
     && ${AG} update \
     && ${AG} upgrade \
     && ${AG} install \
@@ -46,6 +46,7 @@ RUN mkdir -p ${BUILD_DIR} \
            kmod \
            ladvd \
            locales \
+           locales-all \
            libpython3-dev \
            librsvg2-bin \
            libunbound-dev \
@@ -69,18 +70,20 @@ RUN mkdir -p ${BUILD_DIR} \
            wget \
            wpasupplicant \
            ${BUILD_DEPS} \
+# Create venv
     && python3 -m venv /venv \
 # Install Open vSwitch/Mininet
     && mk-build-deps openvswitch -i -r -t "${AG}" \
     && ${BUILD_DIR}/setup.sh \
 # Install docker in docker...
     && ${BUILD_DIR}/dind.sh \
-# Upgrade git for github actions
-    && add-apt-repository -y ppa:git-core/ppa \
-    && ${AG} install git \
 # Cleanup
     && ${AG} purge openvswitch-build-deps ${BUILD_DEPS} \
     && ${AG} autoremove --purge \
     && ${AG} clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf "${BUILD_DIR}"
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 
 FROM ubuntu:18.04
 
-ENV OVSV="v2.14.0"
 ENV MININETV="2.3.0d6"
+ENV OVSV="v2.15.0"
 
 ENV AG="apt-get -qqy --no-install-recommends -o=Dpkg::Use-Pty=0"
 ENV SETUPQ="setup.py -q easy_install --always-unzip ."
@@ -48,6 +48,7 @@ RUN mkdir -p ${BUILD_DIR} \
            locales \
            libpython3-dev \
            librsvg2-bin \
+           libunbound-dev \
            libyaml-dev \
            lsb-release \
            lsof \

--- a/bin/dind.sh
+++ b/bin/dind.sh
@@ -2,12 +2,14 @@
 
 set -euo pipefail
 
+source /etc/os-release
+
 arch=$(dpkg --print-architecture)
 
 case "${arch}" in
     amd64)
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        echo "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [arch=${arch}] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
         ${AG} update
         ${AG} install docker-ce
     ;;

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-echo "will cite" | parallel --citation
-
 git config --global url.https://github.com/.insteadOf git://github.com/
 
 mkdir -p "${BUILD_DIR}"

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -22,9 +22,8 @@ cd mininet || exit 1
 git checkout -b "mininet-${MININETV}" "${MININETV}"
 sed -i -e "s/setup.py install/${SETUPQ}/g" Makefile
 sed -i -e "s/apt-get/${AG}/g" util/install.sh
-for i in ssh pep8 pyflakes python-pexpect pylint xterm ; do
+for i in ssh pep8 pyflakes3 python-pexpect pylint xterm ; do
     sed -i -e "s/${i}//g" util/install.sh
 done
-util/install.sh -n
-pip3 install -q .
+PYTHON=/venv/bin/python util/install.sh -n
 cp util/m /usr/bin/


### PR DESCRIPTION
Change from Ubuntu to Debian so we can keep i386 support for the test base image.

Upgrade:

  * openvswitch to v2.15.0.
  * mininet to v2.3.0.