### PR TITLE
Add FUSE overlayFS support (faucetsdn/faucet#3906)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN mkdir -p ${BUILD_DIR} \
            equivs \
            freeradius \
            fping \
+           fuse-overlayfs \
            git \
            gnupg \
            iperf \


### PR DESCRIPTION
DockerInDocker aufs support doesn't appear to work in the Faucet
test environment any more. Adding FUSE overlayFS support stops
the dependency on aufs from causing issues, by allowing Docker
to select overlayFS support before attempting aufs support.